### PR TITLE
Fix for better compatibility

### DIFF
--- a/DnsTube.Service/install-service.bat
+++ b/DnsTube.Service/install-service.bat
@@ -15,7 +15,7 @@ if %ErrorLevel% equ 0 (
 )
 
 echo Creating service...
-sc create %SERVICE_NAME% binPath="%~dp0DnsTube.Service.exe" start=auto 
+sc create %SERVICE_NAME% binPath= "%~dp0DnsTube.Service.exe" start= auto
 sc description %SERVICE_NAME% "Updates Cloudflare DNS entries with the public IP address of this computer"
 echo Starting service...
 sc start %SERVICE_NAME%


### PR DESCRIPTION
Some Windows versions complain about the lack of a space between the options and the = sign. For example Windows Server 2008 R2.