### PR TITLE
Add extensionless routes

### DIFF
--- a/DnsTube.Service/ClientApp/index.html
+++ b/DnsTube.Service/ClientApp/index.html
@@ -19,9 +19,9 @@
 						<li><strong class="title">DnsTube v2.9</strong></li>
 					</ul>
 					<ul>
-						<li><a role="button" href="/index.html"
-								aria-current="page">Home</a></li>
-						<li><a href="/settings.html">Settings</a></li>
+                                                <li><a role="button" href="/index"
+                                                                aria-current="page">Home</a></li>
+                                                <li><a href="/settings">Settings</a></li>
 					</ul>
 				</nav>
 			</article>

--- a/DnsTube.Service/ClientApp/settings.html
+++ b/DnsTube.Service/ClientApp/settings.html
@@ -19,9 +19,9 @@
 						<li><strong class="title">DnsTube v2.9</strong></li>
 					</ul>
 					<ul>
-						<li><a href="/index.html"
-								aria-current="page">Home</a></li>
-						<li><a role="button" href="/settings.html">Settings</a></li>
+                                                <li><a href="/index"
+                                                                aria-current="page">Home</a></li>
+                                                <li><a role="button" href="/settings">Settings</a></li>
 					</ul>
 				</nav>
 			</article>
@@ -153,7 +153,7 @@
 									<input type="number" name="UpdateIntervalMinutes"
 										id="updateIntervalMinutes" value="30" min="1">
 									<small>Changes to interval take effect the next time the timer fires.
-										Click the <b>update now</b> button on the <a href="/index.html">Home</a>
+                                                Click the <b>update now</b> button on the <a href="/index">Home</a>
 										page to immediately change the schedule</small>
 								</div>
 							</div>

--- a/DnsTube.Service/Program.cs
+++ b/DnsTube.Service/Program.cs
@@ -47,7 +47,21 @@ app.UseRouting();
 app.MapControllers();
 app.MapControllerRoute(name: "default", pattern: "{controller=Home}/{action=Index}/{id?}");
 app.MapServerSentEvents("/sse");
-app.MapGet("/", () => Results.Redirect("/index.html"));
+app.MapGet("/", async context =>
+{
+        context.Response.Headers[HeaderNames.CacheControl] = "no-cache";
+        await context.Response.SendFileAsync(Path.Combine(app.Environment.WebRootPath, "index.html"));
+});
+app.MapGet("/index", async context =>
+{
+        context.Response.Headers[HeaderNames.CacheControl] = "no-cache";
+        await context.Response.SendFileAsync(Path.Combine(app.Environment.WebRootPath, "index.html"));
+});
+app.MapGet("/settings", async context =>
+{
+        context.Response.Headers[HeaderNames.CacheControl] = "no-cache";
+        await context.Response.SendFileAsync(Path.Combine(app.Environment.WebRootPath, "settings.html"));
+});
 app.UseStaticFiles(new StaticFileOptions
 {
 	OnPrepareResponse = ctx =>

--- a/DnsTube.Service/Worker.cs
+++ b/DnsTube.Service/Worker.cs
@@ -117,8 +117,8 @@ namespace DnsTube.Service
                             }
                             else
                             {
-                                _logger.LogWarning($"{validationErrorMessage}, go to {_configuration["Url"]}/settings.html to update");
-                                await _logService.WriteAsync($"{validationErrorMessage}, go to the <a href=\"{_configuration["Url"]}/settings.html\">Settings</a> tab to update", LogLevel.Warning);
+                                _logger.LogWarning($"{validationErrorMessage}, go to {_configuration["Url"]}/settings to update");
+                                await _logService.WriteAsync($"{validationErrorMessage}, go to the <a href=\"{_configuration["Url"]}/settings\">Settings</a> tab to update", LogLevel.Warning);
                             }
                         }
                         else

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ SERVICE_NAME: DnsTube Service
 PS C:\Program Files\DnsTubeService>
 ```
 
-Once the service has started you can view the UI at the URL http://localhost:5666/index.html. See the **Configuration** section for additional config, or if you need to host the UI on a different port.
+Once the service has started you can view the UI at the URL http://localhost:5666/. See the **Configuration** section for additional config, or if you need to host the UI on a different port.
 
 ## Configuration
 
@@ -162,7 +162,7 @@ PS C:\Program Files\DnsTubeService>
 
 1. DnsTube only updates existing Cloudflare records. It will not create or remove records.
 2. Configuration is stored in a separate folder from the application so when you update, your configuration is preserved. (An exception to this is if you have changed the port the application is hosted on in `appsettings.json`.)
-3. The location of the configuration file can be found at the bottom ot the [Settings](http://localhost:5666/settings.html) page.
+3. The location of the configuration file can be found at the bottom ot the [Settings](http://localhost:5666/settings) page.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- map root, `/index`, and `/settings` to the appropriate HTML files without redirects
- update navigation links to use extensionless routes
- adjust log messages and README for new routes

## Testing
- `dotnet build DnsTubeService.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ff14729dc8322ae6833049a6e542c