### PR TITLE
Fix incorrect namespaces

### DIFF
--- a/DnsTube.Core/Interfaces/ILogService.cs
+++ b/DnsTube.Core/Interfaces/ILogService.cs
@@ -1,3 +1,4 @@
+using DnsTube.Core.Models;
 ﻿using Microsoft.Extensions.Logging;
 
 namespace DnsTube.Core.Interfaces

--- a/DnsTube.Core/Interfaces/ISettings.cs
+++ b/DnsTube.Core/Interfaces/ISettings.cs
@@ -1,3 +1,4 @@
+using DnsTube.Core.Models;
 ﻿using DnsTube.Core.Enums;
 
 namespace DnsTube.Core.Interfaces

--- a/DnsTube.Core/Interfaces/ISettingsService.cs
+++ b/DnsTube.Core/Interfaces/ISettingsService.cs
@@ -1,5 +1,6 @@
 using DnsTube.Core.Models;
-﻿namespace DnsTube.Core.Interfaces
+
+namespace DnsTube.Core.Interfaces
 {
 	public interface ISettingsService
 	{

--- a/DnsTube.Core/Interfaces/ISettingsService.cs
+++ b/DnsTube.Core/Interfaces/ISettingsService.cs
@@ -1,3 +1,4 @@
+using DnsTube.Core.Models;
 ﻿namespace DnsTube.Core.Interfaces
 {
 	public interface ISettingsService

--- a/DnsTube.Core/Models/DnsEntry.cs
+++ b/DnsTube.Core/Models/DnsEntry.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DnsTube.Core.Models
+﻿namespace DnsTube.Core.Models
 {
 	public class DnsEntry
 	{

--- a/DnsTube.Core/Models/LogEntry.cs
+++ b/DnsTube.Core/Models/LogEntry.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.Extensions.Logging;
 
-namespace DnsTube.Core.Interfaces
+namespace DnsTube.Core.Models
 {
 	public class LogEntry
 	{

--- a/DnsTube.Core/Models/LogEntry.cs
+++ b/DnsTube.Core/Models/LogEntry.cs
@@ -1,4 +1,4 @@
-﻿using DnsTube.Core.Models;
+﻿using DnsTube.Core.Interfaces;
 
 using Microsoft.Extensions.Logging;
 

--- a/DnsTube.Core/Models/SelectedDomain.cs
+++ b/DnsTube.Core/Models/SelectedDomain.cs
@@ -1,4 +1,4 @@
-﻿namespace DnsTube.Core.Interfaces
+﻿namespace DnsTube.Core.Models
 {
 	public class SelectedDomain
 	{

--- a/DnsTube.Core/Models/Settings.cs
+++ b/DnsTube.Core/Models/Settings.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 
 using DnsTube.Core.Enums;
+using DnsTube.Core.Interfaces;
 
 namespace DnsTube.Core.Models
 {

--- a/DnsTube.Core/Models/Settings.cs
+++ b/DnsTube.Core/Models/Settings.cs
@@ -2,7 +2,7 @@
 
 using DnsTube.Core.Enums;
 
-namespace DnsTube.Core.Interfaces
+namespace DnsTube.Core.Models
 {
 	public class Settings : ISettings
 	{

--- a/DnsTube.Service/Controllers/Api/HistoryController.cs
+++ b/DnsTube.Service/Controllers/Api/HistoryController.cs
@@ -1,4 +1,5 @@
 ﻿using DnsTube.Core.Interfaces;
+using DnsTube.Core.Models;
 
 using Microsoft.AspNetCore.Mvc;
 


### PR DESCRIPTION
## Summary
- correct namespaces for `SelectedDomain`, `Settings` and `LogEntry`
- import the models namespace in related interfaces

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6852b198635c8322b9a071c0122b06dd